### PR TITLE
Fixes Error in Install

### DIFF
--- a/app/Http/Controllers/Application/Servers/ServerController.php
+++ b/app/Http/Controllers/Application/Servers/ServerController.php
@@ -27,7 +27,7 @@ class ServerController extends ApplicationApiController
     public function index(Request $request)
     {
         $servers = QueryBuilder::for(Server::query())
-            ->allowedFilters(['user_id', 'node_id', 'vmid', 'name', 'description', 'installing'])
+            ->allowedFilters(['user_id', 'node_id', 'vmid', 'name', 'description', 'is_installing'])
             ->allowedSorts(['id', 'user_id', 'node_id', 'vmid'])
             ->paginate($request->query('per_page') ?? 50);
 

--- a/app/Http/Middleware/CheckServerInstalling.php
+++ b/app/Http/Middleware/CheckServerInstalling.php
@@ -26,7 +26,7 @@ class CheckServerInstalling
             throw new NotFoundHttpException('Server not found');
         }
 
-        if ($server->installing)
+        if ($server->is_installing)
         {
             if ($request->wantsJson())
             {

--- a/app/Http/Middleware/CheckServerNotInstalling.php
+++ b/app/Http/Middleware/CheckServerNotInstalling.php
@@ -26,7 +26,7 @@ class CheckServerNotInstalling
             throw new NotFoundHttpException('Server not found');
         }
 
-        if (!$server->installing)
+        if (!$server->is_installing)
         {
             if ($request->wantsJson())
             {

--- a/app/Jobs/Servers/ProcessInstallation.php
+++ b/app/Jobs/Servers/ProcessInstallation.php
@@ -37,7 +37,7 @@ class ProcessInstallation implements ShouldQueue
     {
         $server = Server::find($this->serverId);
 
-        $server->update(['installing' => true]);
+        $server->update(['is_installing' => true]);
 
         (new InstallService)->setServer(Template::find($this->templateId)->server)->install($this->vmid, $this->target);
 
@@ -66,6 +66,6 @@ class ProcessInstallation implements ShouldQueue
             $networkService->lockIps(array_column($this->addresses, 'address'));
         }
 
-        $server->update(['installing' => false]);
+        $server->update(['is_installing' => false]);
     }
 }

--- a/app/Jobs/Servers/ProcessReinstallation.php
+++ b/app/Jobs/Servers/ProcessReinstallation.php
@@ -36,10 +36,10 @@ class ProcessReinstallation implements ShouldQueue
         $server = Server::find($this->serverId);
         $template = Template::find($this->templateId)->server;
 
-        $server->update(['installing' => true]);
+        $server->update(['is_installing' => true]);
 
         (new InstallService)->setServer($server)->reinstall($template);
 
-        $server->update(['installing' => false]);
+        $server->update(['is_installing' => false]);
     }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -15,7 +15,7 @@ class Server extends Model
         'user_id',
         'node_id',
         'vmid',
-        'installing'
+        'is_installing'
     ];
 
     public function node()

--- a/app/Transformers/Application/ServerTransformer.php
+++ b/app/Transformers/Application/ServerTransformer.php
@@ -35,7 +35,7 @@ class ServerTransformer extends TransformerAbstract
         return [
             'id' => $server->id,
             'vmid' => $server->vmid,
-            'installing' => $server->installing,
+            'is_installing' => $server->installing,
             'name' => $server->name,
             'user' => $server->user_id,
             'node' => $server->node_id,

--- a/database/migrations/2022_07_25_015911_add_is_installing_column_to_servers_table.php
+++ b/database/migrations/2022_07_25_015911_add_is_installing_column_to_servers_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('servers', function (Blueprint $table) {
-            $table->boolean('installing')->after('make_template_visible')->default(false);
+            $table->boolean('is_installing')->after('make_template_visible')->default(false);
         });
     }
 
@@ -26,7 +26,7 @@ return new class extends Migration
     public function down()
     {
         Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('installing');
+            $table->dropColumn('is_installing');
         });
     }
 };

--- a/database/migrations/2022_08_02_042345_replace_is_installing_column_with_installing_in_servers_table.php
+++ b/database/migrations/2022_08_02_042345_replace_is_installing_column_with_installing_in_servers_table.php
@@ -14,8 +14,8 @@ return new class extends Migration
     public function up()
     {
         Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('installing');
-            $table->boolean('installing')->after('description')->default(false);
+            $table->dropColumn('is_installing');
+            $table->boolean('is_installing')->after('description')->default(false);
         });
     }
 
@@ -27,8 +27,8 @@ return new class extends Migration
     public function down()
     {
         Schema::table('servers', function (Blueprint $table) {
-            $table->dropColumn('installing');
-            $table->boolean('installing')->after('description')->default(false);
+            $table->dropColumn('is_installing');
+            $table->boolean('is_installing')->after('description')->default(false);
         });
     }
 };


### PR DESCRIPTION
When running `php artisan migrate` you run into the following error on a fresh database:

```
SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'installing' (SQL: alter table `servers` add `installing` tinyint(1) not null default '0' after `description`)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:759
    755▕         // If an exception occurs when attempting to run a query, we'll format the error
    756▕         // message to include the bindings with SQL, which will make this exception a
    757▕         // lot more helpful to the developer instead of just the database's errors.
    758▕         catch (Exception $e) {
  ➜ 759▕             throw new QueryException(
    760▕                 $query, $this->prepareBindings($bindings), $e
    761▕             );
    762▕         }
    763▕     }

      +9 vendor frames 
  10  database/migrations/2022_08_02_042345_replace_is_installing_column_with_installing_in_servers_table.php:19
      Illuminate\Support\Facades\Facade::__callStatic()

      +25 vendor frames 
  36  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()

```

Changing from `installing` back to `is_installing`, has fixed the issue for me.